### PR TITLE
Dockerize the backend for ease of use from the front end

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log
+build
+.git
+*.md
+.gitignore

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -19,4 +19,4 @@ RUN npm run build
 CMD [ "npm", "run", "start" ]
 
 # Exposing server port
-EXPOSE 3000
+EXPOSE 5000

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,22 @@
+# Fetching the minified node image on apline linux
+FROM node:slim
+
+# Declaring env
+ENV NODE_ENV development
+
+# Setting up the work directory
+WORKDIR /dogdb-backend
+
+# Copying all the files in our project
+COPY . .
+
+# Installing dependencies
+RUN npm install
+
+RUN npm run build
+
+# Starting our application
+CMD [ "npm", "run", "start" ]
+
+# Exposing server port
+EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ There's a docker-compose.yaml file at the top of the project that has the postgr
 docker-compose up -d
 ```
 
-which should turn on the postgres db. After that, use the T-SQL in the /scripts/init.sql file to create the schema and table and test data if it doesn't already exist. The data should remain persistent when stopping the container, but if you want to start fresh, you can do a
+which should turn on the postgres db. When the postgres image boots up, it will run the T-SQL in the /scripts/init.sql file to create the schema and table and test data if it doesn't already exist. The data should remain persistent when stopping the container, but if you want to start fresh, you can do a
 
 ```bash
 docker-compose down -v
@@ -40,6 +40,12 @@ cd dogdb-backend
 npm install
 or
 yarn
+```
+
+4. Build the project to make sure the .env configuration files will be loaded up and working.  
+
+```bash
+npm run build
 ```
 
 ### Running the Server

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
     restart: unless-stopped
     volumes:
       - db:/var/lib/postgresql/data
+      - ./scripts/init.sql:/docker-entrypoint-initdb.d/init.sql
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
@@ -18,7 +19,7 @@ services:
   #   restart: unless-stopped
   #   environment:
   #     - POSTGRES_HOST=db
-  
+
   dozzle:
     image: amir20/dozzle:latest
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
   #   image: mmanle01/dogdb-service
   #   ports:
   #     # The port number on the left is the one exposed outside of docker.
-  #     - '3000:3000'
+  #     - '5000:5000'
   #   restart: unless-stopped
   #   environment:
   #     - POSTGRES_HOST=db

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,15 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
 
+  # dogdb-service:
+  #   image: mmanle01/dogdb-service
+  #   ports:
+  #     # The port number on the left is the one exposed outside of docker.
+  #     - '3000:3000'
+  #   restart: unless-stopped
+  #   environment:
+  #     - POSTGRES_HOST=db
+  
   dozzle:
     image: amir20/dozzle:latest
     volumes:

--- a/scripts/buildDockerImage.sh
+++ b/scripts/buildDockerImage.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker build -f ../Dockerfile.dev -t mmanle01/dogdb-service ../.

--- a/scripts/init.sql
+++ b/scripts/init.sql
@@ -1,12 +1,13 @@
 CREATE SCHEMA IF NOT EXISTS dogpedia;
+SET search_path TO dogpedia,public;
 
-CREATE TABLE dogpedia.dog_breed (
+CREATE TABLE dog_breed (
     id varchar(150) PRIMARY KEY,
     short_description varchar(150),
     long_description varchar(1024),
     image_path varchar(255)
 );
-ALTER DATABASE postgres SET search_path TO dogpedia;
+
 
 INSERT INTO dog_breed (id, short_description, long_description, image_path)
 values ('German Shephard', 'This is a smart puppy.', 'This is a really, really smart puppy.', '/images/german-shephard.jpg');

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import bodyParser from 'body-parser';
 import dogBreedProvider, { NewDogBreed } from './DB/dogBreedProvider';
 
 const app: Express = express();
-const port = process.env.PORT || 3000;
+const port = process.env.PORT || 5000;
 
 app.use(morgan('combined'));
 app.use(cors());


### PR DESCRIPTION
Added Dockerfile.dev to dockerize the backend and a buildDockerImage.sh script to allow easy building of the docker image. Added and tested a dogdb-service service within the docker-compose.yaml but left it commented out as the typical use case will be to develop/iterate via the actual local build and not using the image. The intent will be to add a docker-compose.yaml file with all the needed services on the frontend repository.

I've pushed the build image to a repo I made here: https://hub.docker.com/repository/docker/mmanle01/dogdb-service/general 